### PR TITLE
Set buildvcs flag to false in docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go mod download
 RUN go get -d -v ./...
 
-RUN go build -o ${GOPATH:-/go}/bin/ ${GOPATH:-/go}/src/temporalite/cmd/temporalite
+RUN go build -buildvcs=false -o ${GOPATH:-/go}/bin/ ${GOPATH:-/go}/src/temporalite/cmd/temporalite
 
 FROM gcr.io/distroless/base-debian11
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

I added a `-buildvcs=false` flag to the `go build` step inside the dockerfile.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is a workaround to https://github.com/temporalio/temporalite/issues/156
I'm not sure if this is the best way to do this, but it does work.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I ran `docker build .` before and after the change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

This may strip VCS information that someone is using, I am not sure if it is necessary to use this flag in the docker image.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No